### PR TITLE
Upgrade to linkerd 1.3.2 and Finagle 7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,19 +1,19 @@
 
 def twitterUtil(mod: String) =
-  "com.twitter" %% s"util-$mod" %  "6.43.0"
+  "com.twitter" %% s"util-$mod" %  "7.1.0"
 
 def finagle(mod: String) =
-  "com.twitter" %% s"finagle-$mod" % "6.44.0"
+  "com.twitter" %% s"finagle-$mod" % "7.1.0"
 
 def linkerd(mod: String) =
-  "io.buoyant" %% s"linkerd-$mod" % "1.0.2"
+  "io.buoyant" %% s"linkerd-$mod" % "1.3.2"
 
 val pathToHost =
   project.in(file("path-to-host")).
     settings(
       scalaVersion := "2.12.1",
       organization := "com.askattest",
-      version := "0.1.0",
+      version := "0.2.0",
       name := "path-to-host",
       resolvers ++= Seq(
         "twitter" at "https://maven.twttr.com",


### PR DESCRIPTION
Upgrade finagle dependencies to 7.1.0 and linkerd to 1.3.2. This is to
ensure that this plugin is compatible with linkerd 1.3.+.